### PR TITLE
Fixing DB Persistence (recommit)

### DIFF
--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/backups/BackupsController.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/backups/BackupsController.java
@@ -1,9 +1,7 @@
 package com.nighthawk.spring_portfolio.mvc.backups;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,9 +10,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.*;
+import java.util.Date;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.Date;
 
 @RestController
 @RequestMapping("/api/exports/")
@@ -99,10 +97,23 @@ public class BackupsController {
                 for (int i = 1; i <= columnCount; i++) {
                     String columnName = metaData.getColumnName(i);
                     Object columnValue = resultSet.getObject(i);
+
+                    // Handle special fields (e.g., stats, kasm_server_needed)
+                    if (columnName.equals("stats") && columnValue instanceof String) {
+                        // If stats is stored as a string, parse it as JSON
+                        columnValue = objectMapper.readValue((String) columnValue, Map.class);
+                    } else if (columnName.equals("kasm_server_needed") && columnValue instanceof Integer) {
+                        // If kasm_server_needed is stored as an integer, convert it to boolean
+                        columnValue = ((Integer) columnValue) == 1;
+                    }
+
                     row.put(columnName, columnValue);
                 }
                 tableData.add(row);
             }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new SQLException("Failed to retrieve data from table: " + tableName, e);
         }
 
         return tableData;

--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/backups/ImportsController.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/backups/ImportsController.java
@@ -1,18 +1,38 @@
 package com.nighthawk.spring_portfolio.mvc.backups;
 
-import org.springframework.stereotype.Component;
-import org.springframework.context.event.EventListener;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.File;
-import java.sql.*;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.Date;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.sqlite.SQLiteException;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
 @RestController
@@ -22,14 +42,19 @@ public class ImportsController {
     private static final String DB_PATH = "./volumes/sqlite.db";
     private static final String BACKUP_DIR = "./volumes/backups/";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    private final Object lock = new Object();
 
-    // Automatically import from the most recent backup on application startup
     @EventListener(ApplicationReadyEvent.class)
-    public void importFromMostRecentBackup() {
+    public synchronized void importFromMostRecentBackup() {
+        // Initialize the database with proper settings
+        initializeDatabase();
+
         File mostRecentBackup = getMostRecentBackupFile();
         if (mostRecentBackup != null) {
-            importFromFile(mostRecentBackup);
+            System.out.println("Importing from backup: " + mostRecentBackup.getName());
+            String result = importFromFile(mostRecentBackup);
+            System.out.println(result);
         } else {
             System.out.println("No backup files found to import.");
         }
@@ -37,38 +62,30 @@ public class ImportsController {
 
     @PostMapping("/manual")
     public String manualImport(@RequestParam("file") MultipartFile file) {
-        if (file.isEmpty()) {
-            return "No file uploaded.";
-        }
+        synchronized (lock) {
+            if (file.isEmpty()) {
+                return "No file uploaded.";
+            }
 
-        try {
-            // Import data directly from the uploaded file
-            String result = importFromMultipartFile(file);
-
-            // Manage backups to keep only the three most recent ones
-            manageBackups();
-
-            return result;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "Failed to process the uploaded file: " + e.getMessage();
+            try {
+                String result = importFromMultipartFile(file);
+                manageBackups();
+                return result;
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "Failed to process the uploaded file: " + e.getMessage();
+            }
         }
     }
 
-    // Helper method to import data directly from a MultipartFile
-    private String importFromMultipartFile(MultipartFile file) {
+    public String importFromMultipartFile(MultipartFile file) {
         try {
-            // Parse the JSON content directly from the MultipartFile
-            Map<String, List<Map<String, Object>>> data = objectMapper.readValue(file.getInputStream(), Map.class);
+            InputStream inputStream = file.getInputStream();
+            String rawJson = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
 
-            try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + DB_PATH)) {
-                for (Map.Entry<String, List<Map<String, Object>>> entry : data.entrySet()) {
-                    String tableName = entry.getKey();
-                    List<Map<String, Object>> tableData = entry.getValue();
-                    insertTableData(connection, tableName, tableData);
-                }
-            }
+            Map<String, List<Map<String, Object>>> data = objectMapper.readValue(rawJson, Map.class);
 
+            sanitizeAndProcessData(data);
             return "Data imported successfully from uploaded file: " + file.getOriginalFilename();
         } catch (Exception e) {
             e.printStackTrace();
@@ -76,27 +93,213 @@ public class ImportsController {
         }
     }
 
-    // Helper method to import data from a JSON file
     private String importFromFile(File jsonFile) {
-        try {
-            Map<String, List<Map<String, Object>>> data = objectMapper.readValue(jsonFile, Map.class);
-
+        int retries = 3;
+        while (retries > 0) {
             try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + DB_PATH)) {
-                for (Map.Entry<String, List<Map<String, Object>>> entry : data.entrySet()) {
-                    String tableName = entry.getKey();
-                    List<Map<String, Object>> tableData = entry.getValue();
-                    insertTableData(connection, tableName, tableData);
-                }
-            }
+                connection.setAutoCommit(false); // Start transaction
 
-            return "Data imported successfully from JSON file: " + jsonFile.getAbsolutePath();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "Failed to import data: " + e.getMessage();
+                // Enable WAL mode for better concurrency
+                enableWalMode(connection);
+                setBusyTimeout(connection, 30000); // 30 seconds
+
+                // Check SQLite version for debugging
+                checkSqliteVersion(connection);
+
+                // Verify database integrity
+                verifyDatabaseIntegrity(connection);
+
+                // Read and parse JSON file
+                String rawJson = new String(Files.readAllBytes(jsonFile.toPath()));
+
+                objectMapper.enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
+                objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+                BackupData backupData = objectMapper.readValue(rawJson, BackupData.class);
+                Map<String, List<Map<String, Object>>> data = backupData.getTables();
+
+                // Sanitize and process data
+                sanitizeAndProcessData(data);
+
+                connection.commit(); // Commit transaction
+                return "Data imported successfully from JSON file: " + jsonFile.getAbsolutePath();
+            } catch (SQLiteException e) {
+                if (e.getMessage().contains("database is locked")) {
+                    retries--;
+                    try {
+                        Thread.sleep(100); // Wait before retrying
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return "Thread interrupted while waiting to retry.";
+                    }
+                } else {
+                    e.printStackTrace();
+                    return "Failed to import data: " + e.getMessage();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "Failed to import data: " + e.getMessage();
+            }
+        }
+        return "Failed to acquire database lock after retries.";
+    }
+
+    public static class BackupData {
+        private Map<String, List<Map<String, Object>>> tables = new HashMap<>();
+
+        @JsonAnySetter
+        public void set(String key, Object value) {
+            if (value instanceof List) {
+                tables.put(key, (List<Map<String, Object>>) value);
+            } else {
+                throw new IllegalArgumentException("Expected a List<Map<String, Object>> for key: " + key);
+            }
+        }
+
+        public Map<String, List<Map<String, Object>>> getTables() {
+            return tables;
+        }
+
+        public void setTables(Map<String, List<Map<String, Object>>> tables) {
+            this.tables = tables;
         }
     }
 
-    // Helper method to find the most recent backup file
+    private void initializeDatabase() {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + DB_PATH)) {
+            // Enable WAL mode for better concurrency
+            enableWalMode(connection);
+
+            // Set a busy timeout to wait for locks
+            setBusyTimeout(connection, 30000); // 30 seconds
+
+            // Check SQLite version for debugging
+            checkSqliteVersion(connection);
+
+            // Verify database integrity
+            verifyDatabaseIntegrity(connection);
+
+            System.out.println("Database initialized successfully.");
+        } catch (SQLException e) {
+            e.printStackTrace();
+            System.err.println("Failed to initialize database: " + e.getMessage());
+        }
+    }
+
+    private void enableWalMode(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA journal_mode=WAL;");
+        }
+    }
+
+    private void disableWalMode(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA journal_mode=DELETE;");
+        }
+    }
+
+    private void setBusyTimeout(Connection connection, int timeoutMillis) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA busy_timeout=" + timeoutMillis + ";");
+        }
+    }
+
+    private void checkSqliteVersion(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT sqlite_version();")) {
+            if (resultSet.next()) {
+                System.out.println("SQLite Version: " + resultSet.getString(1));
+            }
+        }
+    }
+
+    private void verifyDatabaseIntegrity(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("PRAGMA integrity_check;")) {
+            while (resultSet.next()) {
+                System.out.println("Integrity Check: " + resultSet.getString(1));
+            }
+        }
+    }
+
+    private void sanitizeAndProcessData(Map<String, List<Map<String, Object>>> data) throws SQLException {
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite:" + DB_PATH)) {
+            enableWalMode(connection);
+            setBusyTimeout(connection, 30000); // 30 seconds
+
+            // Update sequence tables first
+            updateSequenceTables(connection, data);
+
+            // Insert data into other tables
+            for (Map.Entry<String, List<Map<String, Object>>> entry : data.entrySet()) {
+                String tableName = sanitizeTableName(entry.getKey());
+                List<Map<String, Object>> tableData = entry.getValue();
+                if (!tableName.endsWith("_seq")) { // Skip sequence tables
+                    ensureTableExists(connection, tableName, tableData);
+                    insertTableData(connection, tableName, tableData);
+                }
+            }
+        }
+    }
+
+    private void updateSequenceTables(Connection connection, Map<String, List<Map<String, Object>>> data) throws SQLException {
+        for (Map.Entry<String, List<Map<String, Object>>> entry : data.entrySet()) {
+            String tableName = entry.getKey();
+            if (tableName.endsWith("_seq")) { // Check if it's a sequence table
+                // Create the sequence table if it doesn't exist
+                createSequenceTableIfNotExists(connection, tableName);
+
+                List<Map<String, Object>> tableData = entry.getValue();
+                if (!tableData.isEmpty()) {
+                    Object nextValObj = tableData.get(0).get("next_val");
+                    long nextValFromJson = 0;
+
+                    // Safely handle Integer or Long values
+                    if (nextValObj instanceof Number) {
+                        nextValFromJson = ((Number) nextValObj).longValue();
+                    } else {
+                        throw new IllegalArgumentException("next_val must be a number (Integer or Long)");
+                    }
+
+                    updateSequenceValue(connection, tableName, nextValFromJson);
+                }
+            }
+        }
+    }
+
+    private void createSequenceTableIfNotExists(Connection connection, String tableName) throws SQLException {
+        if (!tableExists(connection, tableName)) {
+            String sql = "CREATE TABLE " + tableName + " (next_val BIGINT NOT NULL)";
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(sql);
+                // Initialize the sequence value to 0 or 1
+                String initSql = "INSERT INTO " + tableName + " (next_val) VALUES (0)";
+                statement.execute(initSql);
+                System.out.println("Created table: " + tableName);
+            }
+        }
+    }
+
+    private boolean tableExists(Connection connection, String tableName) throws SQLException {
+        DatabaseMetaData meta = connection.getMetaData();
+        try (ResultSet resultSet = meta.getTables(null, null, tableName, null)) {
+            return resultSet.next();
+        }
+    }
+
+    private void updateSequenceValue(Connection connection, String tableName, long nextValFromJson) throws SQLException {
+        String sql = "UPDATE " + tableName + " SET next_val = CASE WHEN next_val > ? THEN next_val ELSE ? END";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, nextValFromJson);
+            statement.setLong(2, nextValFromJson);
+            statement.executeUpdate();
+        }
+    }
+
+    private String sanitizeTableName(String tableName) {
+        return tableName.replaceAll("[^a-zA-Z0-9_]", "_");
+    }
+
     private File getMostRecentBackupFile() {
         File backupsDir = new File(BACKUP_DIR);
         if (!backupsDir.exists() || !backupsDir.isDirectory()) {
@@ -108,97 +311,101 @@ public class ImportsController {
             return null;
         }
 
-        // Sort files by last modified date (most recent first)
         Arrays.sort(backupFiles, Comparator.comparingLong(File::lastModified).reversed());
-
-        return backupFiles[0]; // Return the most recent file
+        return backupFiles[0];
     }
 
-    // Helper method to insert data into a table
     private void insertTableData(Connection connection, String tableName, List<Map<String, Object>> tableData) throws SQLException {
         if (tableData.isEmpty()) {
             return;
         }
 
         Set<String> columns = tableData.get(0).keySet();
-        String sql = buildInsertQuery(tableName, columns);
+        String sql = buildUpsertQuery(tableName, columns);
 
         try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             for (Map<String, Object> row : tableData) {
-                if (!isRowExists(connection, tableName, row)) {
-                    int index = 1;
-                    for (String column : columns) {
-                        preparedStatement.setObject(index++, row.get(column));
-                    }
-                    preparedStatement.addBatch();
+                int index = 1;
+                for (String column : columns) {
+                    preparedStatement.setObject(index++, row.get(column));
+                }
+                preparedStatement.addBatch();
+            }
+
+            preparedStatement.executeBatch();
+        }
+    }
+
+    private String buildUpsertQuery(String tableName, Set<String> columns) {
+        String columnList = String.join(", ", columns);
+        String valuePlaceholders = String.join(", ", Collections.nCopies(columns.size(), "?"));
+
+        // Use INSERT OR REPLACE to handle duplicates
+        return "INSERT OR REPLACE INTO " + tableName + " (" + columnList + ") VALUES (" + valuePlaceholders + ")";
+    }
+
+    private void ensureTableExists(Connection connection, String tableName, List<Map<String, Object>> tableData) throws SQLException {
+        if (tableData.isEmpty()) {
+            return;
+        }
+
+        Set<String> columns = tableData.get(0).keySet();
+        if (!tableExists(connection, tableName)) {
+            createTable(connection, tableName, columns);
+        } else {
+            for (String column : columns) {
+                if (!columnExists(connection, tableName, column)) {
+                    addColumn(connection, tableName, column);
                 }
             }
-
-            try {
-                preparedStatement.executeBatch();
-            } catch (SQLException e) {
-                System.err.println("Skipping duplicate entries: " + e.getMessage());
-            }
         }
     }
 
-    // Helper method to check if a row already exists in the table
-    private boolean isRowExists(Connection connection, String tableName, Map<String, Object> row) throws SQLException {
-        StringBuilder queryBuilder = new StringBuilder("SELECT 1 FROM " + tableName + " WHERE ");
-        List<Object> values = new ArrayList<>();
-
-        for (Map.Entry<String, Object> entry : row.entrySet()) {
-            queryBuilder.append(entry.getKey()).append(" = ? AND ");
-            values.add(entry.getValue());
-        }
-
-        queryBuilder.delete(queryBuilder.length() - 5, queryBuilder.length()); // Remove the last " AND "
-
-        try (PreparedStatement preparedStatement = connection.prepareStatement(queryBuilder.toString())) {
-            int index = 1;
-            for (Object value : values) {
-                preparedStatement.setObject(index++, value);
-            }
-
-            try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                return resultSet.next();
-            }
-        }
-    }
-
-    // Helper method to build the INSERT query
-    private String buildInsertQuery(String tableName, Set<String> columns) {
-        StringBuilder columnsBuilder = new StringBuilder();
-        StringBuilder valuesBuilder = new StringBuilder();
-
+    private void createTable(Connection connection, String tableName, Set<String> columns) throws SQLException {
+        StringBuilder sqlBuilder = new StringBuilder("CREATE TABLE " + tableName + " (");
         for (String column : columns) {
-            columnsBuilder.append(column).append(",");
-            valuesBuilder.append("?,");
+            if (column.equalsIgnoreCase("id")) {
+                sqlBuilder.append(column).append(" INTEGER PRIMARY KEY AUTOINCREMENT,");
+            } else {
+                sqlBuilder.append(column).append(" TEXT,");
+            }
         }
+        sqlBuilder.deleteCharAt(sqlBuilder.length() - 1);
+        sqlBuilder.append(")");
 
-        columnsBuilder.deleteCharAt(columnsBuilder.length() - 1);
-        valuesBuilder.deleteCharAt(valuesBuilder.length() - 1);
-
-        return "INSERT OR IGNORE INTO " + tableName + " (" + columnsBuilder + ") VALUES (" + valuesBuilder + ")";
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sqlBuilder.toString());
+        }
     }
 
-     private void manageBackups() {
+    private boolean columnExists(Connection connection, String tableName, String columnName) throws SQLException {
+        DatabaseMetaData meta = connection.getMetaData();
+        try (ResultSet resultSet = meta.getColumns(null, null, tableName, columnName)) {
+            return resultSet.next();
+        }
+    }
+
+    private void addColumn(Connection connection, String tableName, String columnName) throws SQLException {
+        String sql = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " TEXT";
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private void manageBackups() {
         File backupsDir = new File(BACKUP_DIR);
         if (!backupsDir.exists() || !backupsDir.isDirectory()) {
             return;
         }
 
-        // Get all backup files
         File[] backupFiles = backupsDir.listFiles((dir, name) -> name.startsWith("backup_") && name.endsWith(".json"));
 
         if (backupFiles == null || backupFiles.length <= 3) {
             return;
         }
 
-        // Sort files by last modified date (oldest first)
         Arrays.sort(backupFiles, Comparator.comparingLong(File::lastModified));
 
-        // Delete the oldest files if there are more than three
         for (int i = 0; i < backupFiles.length - 3; i++) {
             if (backupFiles[i].delete()) {
                 System.out.println("Deleted old backup: " + backupFiles[i].getName());


### PR DESCRIPTION
Added special handling for the Stats and Kasm column of the Person DB (they were breaking functionality)
Added SQLITE DB integrity checks at startup to ensure the sqlite.db isn't corrupted
Added Special handling for sequence databases to get rid of duplicate entries
Added Special handling for new sequence databases
I guess this also stops the server from automatically crashing on startup