### PR TITLE
Important!!!! Fixing bug with balance saving

### DIFF
--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/person/PersonViewController.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/person/PersonViewController.java
@@ -152,7 +152,7 @@ public class PersonViewController {
         if (person.getSid() != null && !person.getSid().equals(personToUpdate.getSid())) {
             personToUpdate.setSid(person.getSid());
         }
-        if (person.getBalance() != null && !person.getBalance().equals(personToUpdate.getBalance())) {
+        if (person.getBalance() != null && !person.getBalance().isBlank() && !person.getBalance().equals(personToUpdate.getBalance())) {
             personToUpdate.setBalance(person.getBalance());
         }
                 


### PR DESCRIPTION
update bug that allows people to update balance to a blank value

This should **NOT** be possible, and was a result of a misunderstanding that balance was stored as a number and not as a string.

A person with a blank balance breaks the "api/person" (and probably the "api/people") endpoint.

While this should fix that issue, I beg whatever team is in charge of balance to switch it to saving as a Double or something similar in the Database.