### PR TITLE
Bug Fix for needing to delete DB after first run, and also removed unecessary restore code. 

### DIFF
--- a/src/main/java/com/nighthawk/spring_portfolio/mvc/dbFix/DatabaseConfigListener.java
+++ b/src/main/java/com/nighthawk/spring_portfolio/mvc/dbFix/DatabaseConfigListener.java
@@ -1,0 +1,32 @@
+package com.nighthawk.spring_portfolio.mvc.dbFix;
+
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class DatabaseConfigListener {
+    
+    @Bean
+    public JpaProperties jpaProperties() {
+        JpaProperties properties = new JpaProperties();
+        
+        File dbFile = new File("volumes/sqlite.db");
+        
+        Map<String, String> hibernateProps = new HashMap<>();
+        
+        if (dbFile.exists()) {
+            hibernateProps.put("hibernate.hbm2ddl.auto", "none");
+        } else {
+            hibernateProps.put("hibernate.hbm2ddl.auto", "update");
+        }
+        
+        properties.setProperties(hibernateProps);
+        
+        return properties;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,6 @@ server.error.whitelabel.enabled=false
 spring.devtools.add-properties=false
 logging.level.root=warn
 spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
-spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.open-in-view=false
@@ -24,3 +23,13 @@ spring.mail.username=dnhsbathroom@gmail.com
 spring.mail.password=vjor zncp naam daph
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+spring.datasource.url=jdbc:sqlite:volumes/sqlite.db?journal_mode=WAL
+
+spring.jpa.hibernate.ddl-auto=none
+spring.datasource.url: jdbc:sqlite:volumes/sqlite.db?busy_timeout=60000
+
+spring.datasource.hikari.connection-timeout=60000
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.validation-timeout=3000
+spring.datasource.hikari.max-lifetime=1800000


### PR DESCRIPTION
making it so that imports for the database don't wipe columns and tables that aren't included in JSON. Also made it so that ddl-auto is swapped between "update" and "none" as needed to fix the issue with needing to delete the DB.